### PR TITLE
Don't override changes to the welcome document

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
     }
 
     document.body.onload = () => {
-      saveDoc("Welcome to Xnoe Notes!", "Welcome to Xnoe Notes!\nClick here to start writing!");
+      !localStorage.hasOwnProperty("Welcome to Xnoe Notes!")? saveDoc("Welcome to Xnoe Notes!", "Welcome to Xnoe Notes!\nClick here to start writing!"): false;
       loadDoc(getCur());
 
       document.getElementById("file").addEventListener('change', loadFile, false);


### PR DESCRIPTION
Currently the welcome document gets overriden each time xnoenotes is loaded. This might be something somebody would not know causing them to lose notes.